### PR TITLE
Doplňení spravného endpointu do dokumentace

### DIFF
--- a/moduly/themes.md
+++ b/moduly/themes.md
@@ -4,7 +4,7 @@ vrací seznam hodin a jejich témata za celý školní rok v daném předmětu
 
 ## Požadavek
 ```
-GET /api/3/subjects/{subject_id}
+GET /api/3/subjects/themes/{subject_id}
 "Content-Type: application/x-www-form-urlencoded"
 "Authorization: Bearer ACCESS_TOKEN"
 ```


### PR DESCRIPTION
Správný endpoint pro získání seznam hodin je "/api/3/subjects/themes/{subject_id}", ale v požadavku je napsáno pouze "/api/3/subjects/{subject_id}"